### PR TITLE
Had a race condition with postgrest/postgresql container linking when trying to run on mac 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 docker-postgrest-with-postgresql
 --------------------------------
 
+For some reason, when using docker-compose on OSX/with docker-machine/boot2docker, the postgrest containers steadfastly refused 
+to connect to the db container. So I wrote a little bash script to replace the docker-compose.yml
+
 Links together the official Docker image for PostgreSQL and an up-to-date variant of the one supplied in the PostgREST wiki (https://github.com/begriffs/postgrest/wiki/Docker)
 
 ### Prerequisites
@@ -10,13 +13,13 @@ Links together the official Docker image for PostgreSQL and an up-to-date varian
 
 ## Local Usage
 
-When using locally, you can access the containers on:
-- http://localhost:5432
-- http://localhost:80
+You can access the containers on:
+- http://$(docker-machine ip):5432
+- http://$(docker-machine ip):80
 
 ### Getting Started
 
-To start the containers, run: ```docker-compose up -d```
+To start the containers, run: ```./runDockerBuild```
 
 If you want to define the schema prior to starting the containers, place the required .sql or .sh files within the _postgresql/scripts_ directory.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
 api:
   build: ./postgrest/
   ports:
-    - 3000:3000
+    - "3000:3000"
   links:
     - db
   restart: always
 db:
   build: ./postgresql/
   environment:
-    POSTGRES_PASSWORD: foobar
+  # see .sql file for alter table statement that assigns password
+    POSTGRES_PASSWORD: postgres
   ports:
-    - 5432:5432
+    - "5432:5432"

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,2 +1,5 @@
 FROM postgres
 ADD ./scripts/ /docker-entrypoint-initdb.d/
+
+
+EXPOSE 5432

--- a/postgrest/Dockerfile
+++ b/postgrest/Dockerfile
@@ -8,10 +8,7 @@ RUN wget https://github.com/begriffs/postgrest/releases/download/v${POSTGREST_VE
 RUN tar --xz -xvf postgrest-${POSTGREST_VERSION}-centos.tar.xz
 RUN mv postgrest /usr/local/bin/postgrest
 
-CMD postgrest  postgres://postgres:foobar@db:5432/postgres \
-               --port 3000 \
-               --schema public \
-               --anonymous postgres \
-               --pool 200
+COPY waitForPostgresqlConnection.sh /
+ENTRYPOINT ["/waitForPostgresqlConnection.sh"]
 
 EXPOSE 3000

--- a/postgrest/waitForPostgresqlConnection.sh
+++ b/postgrest/waitForPostgresqlConnection.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+su -c "
+    while ! psql --host=${db} --username=postgres > /dev/null 2>&1; do
+        echo 'Waiting for webappservicedb connection with postgres...'
+        sleep 1;
+    done;
+    echo 'Connected to postgres...';"
+su -c "postgrest postgres://postgres:postgres@db:5432 \
+           --port 3000 \
+           --schema public \
+           --anonymous postgres \
+           --pool 200"


### PR DESCRIPTION
hopefully if you/others run in to a similar problem this *might* fix it.
see https://github.com/docker/docker/issues/7445
http://gregoryszorc.com/blog/2014/10/16/the-rabbit-hole-of-using-docker-in-automated-tests/
I encountered issue after adding a sql file with a couple of relations into /postgresql/scripts,
that might be a way to reproduce, might only be a problem when running boot2docker/dockermachine though, cuz the restart flag did nothing for me sadly, container was just continuously restarting without establishing a connection (believe me I checked to make sure it wasn't a problem with port forwarding/nested vm ip addresses)

Thanks for putting the repo together, this is my first pull request :P 